### PR TITLE
Allow shm property to be skipped

### DIFF
--- a/charts/blockscout-stack/templates/postgres/deployment.yaml
+++ b/charts/blockscout-stack/templates/postgres/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-postgres-pv-claim
         {{- end }}
-        {{- if .Values.postgres.customShm.enabled }}
+        {{- if and .Values.postgres.customShm .Values.postgres.customShm.enabled }}
         - name: dshm
           emptyDir:
             medium: Memory

--- a/charts/blockscout-stack/templates/postgres/deployment.yaml
+++ b/charts/blockscout-stack/templates/postgres/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - containerPort: {{ .Values.postgres.port }}
           env:
 {{- include "postgres_env" . | indent 10 }}
-          {{- if or ( .Values.postgres.persistence ) ( .Values.postgres.files.enabled ) }}
+          {{- if or ( .Values.postgres.persistence ) ( .Values.postgres.files.enabled ) ( .Values.postgres.customShm.enabled ) }}
           volumeMounts:
             {{- if .Values.postgres.persistence }}
             - mountPath: {{ .Values.postgres.mountPath }}
@@ -80,14 +80,14 @@ spec:
       nodeSelector:
       {{- pluck $.Values.global.env .Values.postgres.nodeSelector.labels | first | default .Values.postgres.nodeSelector.labels._default | toYaml | nindent 8 }}
       {{- end }}
-      {{- if or ( .Values.postgres.persistence ) ( .Values.postgres.files.enabled ) }}
+      {{- if or ( .Values.postgres.persistence ) ( .Values.postgres.files.enabled ) ( .Values.postgres.customShm.enabled ) }}
       volumes:
         {{- if .Values.postgres.persistence }}
         - name: postgredb
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-postgres-pv-claim
         {{- end }}
-        {{- if and .Values.postgres.customShm .Values.postgres.customShm.enabled }}
+        {{- if .Values.postgres.customShm.enabled }}
         - name: dshm
           emptyDir:
             medium: Memory

--- a/charts/blockscout-stack/values.yaml
+++ b/charts/blockscout-stack/values.yaml
@@ -111,6 +111,9 @@ postgres:
   command:
   args:
 
+  customShm:
+    enabled: false
+
   strategy: RollingUpdate
 
   service:

--- a/charts/blockscout-stack/values/e2e/values.yaml
+++ b/charts/blockscout-stack/values/e2e/values.yaml
@@ -146,6 +146,9 @@ postgres:
   command: '["docker-entrypoint.sh", "-c"]'
   args: '["max_connections=300"]'
 
+  customShm:
+    enabled: false
+
   files:
     enabled: true
     mountPath: /docker-entrypoint-initdb.d
@@ -153,8 +156,6 @@ postgres:
       init.sql: |
         CREATE DATABASE stats;
         GRANT ALL PRIVILEGES ON DATABASE stats TO postgres;
-  customShm:
-    enabled: false
 
   resources:
     limits:

--- a/charts/blockscout-stack/values/gnosis/values.yaml
+++ b/charts/blockscout-stack/values/gnosis/values.yaml
@@ -134,6 +134,9 @@ postgres:
   command: '["docker-entrypoint.sh", "-c"]'
   args: '["max_connections=300"]'
 
+  customShm:
+    enabled: false
+
   files:
     enabled: true
     mountPath: /docker-entrypoint-initdb.d


### PR DESCRIPTION
Currently, deployment will fail, if `customShm` property is missing on `postgres` object.

The aim of this PR to make `customShm` property optional.